### PR TITLE
Prevent TypeError when using .length

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 // adapted from https://github.com/grawity/code/blob/master/lib/python/nullroute/irc.py#L24-L53
 
 module.exports = function parsePrefix(prefix) {
-    if (prefix.length === 0) {
+    try {
+        if (prefix.length === 0) {
+            return null
+        }
+    } catch(e) {
         return null
     }
 


### PR DESCRIPTION
Sometimes, the prefix is null and it is causing the following error:

``` bash
TypeError: Cannot read property 'length' of null
    at parsePrefix (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\irc-message\node_modules\irc-prefix-parser\index.js:4:15)
    at DestroyableTransform._transform (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\irc-message\index.js:159:33)
    at DestroyableTransform.Transform._read (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\readable-stream\lib\_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\readable-stream\lib\_stream_transform.js:172:12)
    at doWrite (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\readable-stream\lib\_stream_writable.js:237:10)
    at writeOrBuffer (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\readable-stream\lib\_stream_writable.js:227:5)
    at DestroyableTransform.Writable.write (C:\Users\Schmoopiie\Desktop\Development\twitch-irc\node_modules\readable-stream\lib\_stream_writable.js:194:11)
    at Socket.ondata (_stream_readable.js:540:20)
    at Socket.emit (events.js:107:17)
    at readableAddChunk (_stream_readable.js:163:16)
```

It happens when receiving PING request from the server. It would be awesome if you could update it and also update the version in irc-message.. otherwise I won't be able to use the parser in the latest version of irc-message because the client is crashing after 5 minutes (when the first PING request happens).

Thank you! :smile: 
